### PR TITLE
Confirmation number was  off by one

### DIFF
--- a/data/sql/headers.go
+++ b/data/sql/headers.go
@@ -293,7 +293,7 @@ func (h *HeadersDb) CalculateConfirmations(ctx context.Context, height int32) (i
 		configs.Log.Error("sql error", err)
 		return 0, errors.Wrapf(err, "failed to calculate confirmations for block at height: %d", height)
 	}
-	amount := int(tip[0].Height - height)
+	amount := int(tip[0].Height - height + 1)
 	return amount, nil
 }
 


### PR DESCRIPTION
confirmations should be Tip  height - height of header in question + 1.

Otherwise the current tip has 0 confirmations which is wrong. Comparing  to HeaderSV - this is the convention.