### PR TITLE
Much more performant tips endpoint

### DIFF
--- a/data/sql/headers.go
+++ b/data/sql/headers.go
@@ -127,13 +127,6 @@ const (
 	LIMIT 100
 	`
 
-	sqlSelectTips = `
-	SELECT hash, height, version, merkleroot, nonce, bits, chainwork, previousblock, timestamp, cumulatedWork, header_state
-	FROM headers
-	WHERE hash NOT IN (SELECT previousblock
-					   FROM headers)
-				   `
-
 	sqlChainBetweenTwoHashes = `
 	WITH RECURSIVE ancestors(hash, height, version, merkleroot, nonce, bits, chainwork, previousblock, timestamp, cumulatedWork, level) AS (
 		SELECT hash, height, version, merkleroot, nonce, bits, chainwork, previousblock, timestamp, cumulatedWork, 0 level


### PR DESCRIPTION
Enhances [performance issue](https://github.com/libsv/pulse/issues/107).

Achieved by limiting the query to the top 100 headers, and performing the "tips only" logic on that small set.

100 was chosen because any tips prior to 100 blocks back in history should be rejected anyway as this is most likely an attack.

Response time is down from 8 full seconds to 340ms.